### PR TITLE
Fix "on behalf of" display in outlook

### DIFF
--- a/WireMailMailgun.module
+++ b/WireMailMailgun.module
@@ -351,6 +351,7 @@ class WireMailMailgun extends WireMail implements Module {
 
 		// Set the From field in the proper format
 		$data["from"] = "{$fromName} <{$fromEmail}>";
+    		$data["h:sender"] = $data["from"];
 
 		// Set recipients
 		$data["to"] = $this->getEmails($this->mail["toName"]);


### PR DESCRIPTION
If you use a subdomain in mailgun, as described in their official docs, the from address in Outlook is displayed strange, which could confuse users. 
See detail pane of the message
![OUTLOOK_2019-05-27_12-50-28](https://user-images.githubusercontent.com/551551/58418652-af82c000-8088-11e9-9c1b-0ec1254e3607.png)
You can read about it here https://help.mailgun.com/hc/en-us/articles/360012491394-Why-Do-I-See-On-Behalf-Of-in-My-Email-
The problem can be solved when from and sender headers are the same. The solution was found here https://stackoverflow.com/a/45445015/616067